### PR TITLE
feat: add Renovate configuration files for dependency management

### DIFF
--- a/.github/renovate/default.json
+++ b/.github/renovate/default.json
@@ -1,0 +1,29 @@
+{
+  "packageRules": [
+    {
+      "extends": [
+        "local>Blouppy/http-file-generator//.github/renovate/rules/npm"
+      ]
+    },
+    {
+      "extends": [
+        "local>Blouppy/http-file-generator//.github/renovate/rules/nextjs"
+      ]
+    },
+    {
+      "extends": [
+        "local>Blouppy/http-file-generator//.github/renovate/rules/jest"
+      ]
+    },
+    {
+      "extends": [
+        "local>Blouppy/http-file-generator//.github/renovate/rules/tailwind"
+      ]
+    },
+    {
+      "extends": [
+        "local>Blouppy/http-file-generator//.github/renovate/rules/eslint"
+      ]
+    }
+  ]
+}

--- a/.github/renovate/rules/eslint.json
+++ b/.github/renovate/rules/eslint.json
@@ -1,0 +1,14 @@
+{
+  "packageRules": [
+    {
+      "matchManagers": ["npm"],
+      "matchPackageNames": [
+        "eslint",
+        "eslint-config-prettier",
+        "eslint-plugin-prettier",
+        "typescript-eslint"
+      ],
+      "groupName": "ESLint packages"
+    }
+  ]
+} 

--- a/.github/renovate/rules/jest.json
+++ b/.github/renovate/rules/jest.json
@@ -1,0 +1,12 @@
+{
+  "matchManagers": ["npm"],
+  "matchPackageNames": [
+    "jest",
+    "jest-environment-jsdom",
+    "ts-jest",
+    "@types/jest",
+    "@testing-library/react",
+    "@testing-library/jest-dom"
+  ],
+  "groupName": "jest and testing library"
+}

--- a/.github/renovate/rules/nextjs.json
+++ b/.github/renovate/rules/nextjs.json
@@ -1,0 +1,5 @@
+{
+  "matchManagers": ["npm"],
+  "matchPackageNames": ["next", "react", "react-dom", "eslint-config-next"],
+  "groupName": "nextjs core"
+}

--- a/.github/renovate/rules/npm.json
+++ b/.github/renovate/rules/npm.json
@@ -1,0 +1,4 @@
+{
+  "matchManagers": ["npm"],
+  "labels": ["dependencies 📦", "npm"]
+}

--- a/.github/renovate/rules/tailwind.json
+++ b/.github/renovate/rules/tailwind.json
@@ -1,0 +1,5 @@
+{
+  "matchManagers": ["npm"],
+  "matchPackageNames": ["tailwindcss", "postcss", "autoprefixer", "tailwind-merge"],
+  "groupName": "tailwind and css tooling"
+}

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    "local>Blouppy/http-file-generator//.github/renovate/default"
+  ],
+  "assignees": ["@jboinembalome"],
+  "commitMessagePrefix": "chore(deps):",
+  "baseBranches": ["master"],
+  "branchPrefix": "renovate/",
+  "additionalBranchPrefix": "{{parentDir}}/",
+  "schedule": [
+    "after 9pm every weekday",
+    "before 9am every weekday",
+    "every weekend"
+  ],
+  "major": {
+    "automerge": false
+  },
+  "minor": {
+    "automerge": false
+  },
+  "patch": {
+    "automerge": true
+  },
+  "dependencyDashboard": true,
+  "timezone": "Europe/Paris"
+}


### PR DESCRIPTION
## 📝 Description
This pull request introduces a comprehensive Renovate configuration to automate and manage dependency updates for the project. It sets up both global and granular rules to group updates by technology stack, control automerge behavior, and customize scheduling and labeling.

---

## 🎯 Motivation & Impact
Key changes include:

**Global Renovate configuration:**

* Added a `renovate.json` file with project-wide settings, including scheduling, branch naming conventions, automerge rules for patch updates, dependency dashboard activation, and timezone specification.

**Default and technology-specific rules:**

* Introduced `.github/renovate/default.json` to aggregate and extend local rules for npm, Next.js, Jest, Tailwind, and ESLint, ensuring consistent grouping and management of dependencies.

**Dependency grouping by stack:**

  - **Next.js and React:**
    * Created `.github/renovate/rules/nextjs.json` to group core Next.js and React packages for updates.
  - **Jest and Testing Libraries:**
    * Added `.github/renovate/rules/jest.json` to group Jest and related testing libraries.
  - **Tailwind and CSS Tooling:**
    * Added `.github/renovate/rules/tailwind.json` to group Tailwind CSS and related tools.
  - **ESLint and Linting:**
    * Introduced `.github/renovate/rules/eslint.json` to group ESLint and related packages.

**General npm rule:**

* Added `.github/renovate/rules/npm.json` to apply labels to all npm dependency updates for easier tracking.

---

## 🔗 Links (optional)
Related Issue(s):
- Fixes #5 

---
