### PR TITLE
feat: update landing page

### DIFF
--- a/src/lib/translations.ts
+++ b/src/lib/translations.ts
@@ -100,7 +100,7 @@ export const translations = {
     homeTitle: "HTTP File Generator",
     homeSubtitle: "Transform your OpenAPI specifications into ready-to-use .http files in seconds",
     homeGetStarted: "Get Started",
-    homeCompatibleWith: "Compatible with VS Code REST Client & JetBrains HTTP Client",
+    homeCompatibleWith: "Compatible with VS Code REST Client",
     homePreviewTitle: "See it in action",
     homePreviewDesc:
       "Browse your endpoints, select exactly what you need, and instantly preview the generated .http file.",
@@ -222,7 +222,7 @@ export const translations = {
     homeSubtitle:
       "Transformez vos spécifications OpenAPI en fichiers .http prêts à l'emploi en quelques secondes",
     homeGetStarted: "Commencer",
-    homeCompatibleWith: "Compatible avec VS Code REST Client & JetBrains HTTP Client",
+    homeCompatibleWith: "Compatible avec VS Code REST Client",
     homePreviewTitle: "Voyez-le en action",
     homePreviewDesc:
       "Parcourez vos endpoints, sélectionnez exactement ce dont vous avez besoin, et prévisualisez instantanément le fichier .http généré.",


### PR DESCRIPTION
## 📝 Description

Updated the `homeCompatibleWith` translation string in `src/lib/translations.ts` to remove "JetBrains HTTP Client" from both English and French language sections.

---

## 🎯 Motivation & Impact

This pull request makes a minor update to the compatibility messaging in the application's translations. The change removes the mention of "JetBrains HTTP Client" from the compatibility statement in both English and French translations, clarifying that the tool is only compatible with VS Code REST Client.

---

## 🔗 Links (optional)

Related Issue(s):

---
